### PR TITLE
Fix: Resolve header overlap on mobile devices

### DIFF
--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -8,7 +8,7 @@ import heroImage from '../assets/images/SrinivasanSekar.webp' // Added import
 
 export default function Home() {
   return (
-    <main className="pt-16"> {/* Added padding-top to account for sticky header */}
+    <main className="pt-36 md:pt-24 lg:pt-20"> {/* Added padding-top to account for sticky header */}
       {/* Hero Section */}
       <section id="top" className="py-20 text-center bg-custom-black text-custom-gray-light">
         <div className="container mx-auto">


### PR DESCRIPTION
The sticky header was overlapping the hero section content (image and name) on mobile screens. This was due to insufficient top padding on the main content area.

This commit addresses the issue by:
1. Modifying `src/screens/Home.tsx` to use responsive top padding on the `main` element.
   - Changed from `pt-16` to `pt-36 md:pt-24 lg:pt-20`.
   - This ensures adequate space for the header on small screens (9rem), medium screens (6rem), and large screens (5rem), accommodating its varying height due to flex direction changes and text wrapping.

This change resolves the visual overlap on mobile and ensures appropriate spacing across different viewport sizes.